### PR TITLE
Add a random sentinel to close channel when terminates

### DIFF
--- a/data/exploits/CVE-2016-0099/cve_2016_0099.ps1
+++ b/data/exploits/CVE-2016-0099/cve_2016_0099.ps1
@@ -354,6 +354,7 @@
 			$CallResult = [Kernel32]::ResumeThread($ProcessInfo.hThread)
 			$StartTokenRace.Stop()
 			$SafeGuard.Stop()
+            echo "$end"
 			Return
 		}
 			

--- a/data/exploits/CVE-2016-0099/cve_2016_0099.ps1
+++ b/data/exploits/CVE-2016-0099/cve_2016_0099.ps1
@@ -354,7 +354,7 @@
 			$CallResult = [Kernel32]::ResumeThread($ProcessInfo.hThread)
 			$StartTokenRace.Stop()
 			$SafeGuard.Stop()
-            echo "$end"
+			echo "$end"
 			Return
 		}
 			

--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -126,6 +126,8 @@ class MetasploitModule < Msf::Exploit::Local
     ms16_032.gsub!("$cmd","\"#{cmdstr}\"")
     #lpcommandLine - capped at 1024b
     ms16_032.gsub!("$args1","\"#{psh_cmd}\"")
+    end_flag = Rex::Text.rand_text_alphanumeric(32)
+    ms16_032.gsub!("$end","\"#{end_flag}\"")
 
     print_status('Compressing script contents...')
     ms16_032_c = compress_script(ms16_032)
@@ -160,6 +162,7 @@ class MetasploitModule < Msf::Exploit::Local
 
       while(d = r.channel.read)
         print(d)
+        break if d =~ /#{end_flag}/
       end
       r.channel.close
       r.close

--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -127,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Local
     #lpcommandLine - capped at 1024b
     ms16_032.gsub!("$args1","\"#{psh_cmd}\"")
     end_flag = Rex::Text.rand_text_alphanumeric(32)
-    ms16_032.gsub!("$end","\"#{end_flag}\"")
+    ms16_032.gsub!("$end", end_flag)
 
     print_status('Compressing script contents...')
     ms16_032_c = compress_script(ms16_032)
@@ -162,7 +162,7 @@ class MetasploitModule < Msf::Exploit::Local
 
       while(d = r.channel.read)
         print(d)
-        break if d =~ /#{end_flag}/
+        break if d.include? end_flag
       end
       r.channel.close
       r.close


### PR DESCRIPTION
Adding a random sentinel value in the Powershell script to terminate the channel when it is done. This will prevent the execution to hang. Note that it is just a workaround, the Powershell process will still be be running on the remote target.