### PR TITLE
Move clean-up code to cleanup method

### DIFF
--- a/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
+++ b/modules/exploits/windows/local/ms16_032_secondary_logon_handle_privesc.rb
@@ -169,11 +169,13 @@ class MetasploitModule < Msf::Exploit::Local
 
       print_good("Executed on target machine.")
 
-      rm_f(@upfile)
-
-      print_good("Deleted #{@upfile}")
     rescue
       print_error("An error occurred executing the script.")
     end
+  end
+
+  def cleanup
+    rm_f(@upfile)
+    print_good("Deleted #{@upfile}")
   end
 end


### PR DESCRIPTION
This will ensure the clean-up is done after the session is created. If necessary, the `WfsDelay` advanced option can be adjusted to make sure the module will wait long enough before cleaning up.